### PR TITLE
Added method getViewIntent, which is missing in the code sample

### DIFF
--- a/app-indexing/app/src/main/java/com/recipe_app/client/Recipe.java
+++ b/app-indexing/app/src/main/java/com/recipe_app/client/Recipe.java
@@ -130,6 +130,14 @@ public class Recipe {
         return recipe;
     }
 
+    public Intent getViewIntent(Context context) {
+        Intent intent = new Intent(context, RecipeActivity.class);
+        intent.setAction(Intent.ACTION_VIEW);
+        intent.setData(Uri.parse(getUrl()));
+        return intent;
+    }
+
+
     public static class Ingredient {
         private String amount;
         private String description;


### PR DESCRIPTION
 In the Google codelabs example, this method is missing and it is nowhere mentioned that the user should add it.
